### PR TITLE
Catch errors during `repr` of spec-class attributes.

### DIFF
--- a/spec_classes/methods/core.py
+++ b/spec_classes/methods/core.py
@@ -10,6 +10,7 @@ from collections.abc import (
     MutableSequence,
     MutableSet,
 )
+from dataclasses import dataclass
 from typing import Any
 
 from spec_classes.errors import FrozenInstanceError
@@ -333,6 +334,16 @@ class ReprMethod(MethodDescriptor):
 
     method_name = "__init__"
 
+    @dataclass
+    class ExceptionRepr:
+        exception: BaseException
+
+        def __repr__(self):
+            return (
+                f"⧛⚠️{type(self.exception).__name__}: "
+                f"{self.exception.args[0] if self.exception.args else ''}⧚"
+            )
+
     @staticmethod
     def repr(
         self,  # noqa: PLW0211
@@ -384,7 +395,10 @@ class ReprMethod(MethodDescriptor):
         attr_values = {}
         for attr in include_attrs:
             if attr not in exclude_attrs:
-                attr_values[attr] = getattr(self, attr, MISSING)
+                try:
+                    attr_values[attr] = getattr(self, attr, MISSING)
+                except Exception as e:
+                    attr_values[attr] = ReprMethod.ExceptionRepr(e)
 
         def object_repr(obj, indent=False):
             if obj is self:

--- a/tests/test_spec_class.py
+++ b/tests/test_spec_class.py
@@ -1203,3 +1203,14 @@ class TestFramework:
             ),
         ):
             A(a="string")
+
+    def test_repr_exception_handling(self):
+        @spec_class
+        class A:
+            a: int
+
+            @spec_property
+            def a(self):
+                raise RuntimeError("Error in repr")
+
+        assert repr(A()) == "A(a=⧛⚠️RuntimeError: Error in repr⧚)"


### PR DESCRIPTION
Previously if an attribute failed evaluation, then the whole repr would fail; which was not great for interactive use-cases. Now, spec-classes that raise during repr will have their exception rendered into the repr.

For example:
```python
from spec_classes import spec_class, spec_property

@spec_class
class MySpec:
    a: int

    @spec_property
    def a(self) -> int:
        raise ValueError("Not real!")

repr(MySpec())
```

outputs:
```
MySpec(a=⧛⚠️ValueError: Not real!⧚)
```